### PR TITLE
ADD ability to set runner concurrent setting

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,4 @@ gitlab_transport: 'https'
 gitlab_port: '8443'
 docker_runner: true
 shell_runner: false
+gitlab_concurrent: -1  # default to number of cores

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -1,4 +1,8 @@
+{% if gitlab_concurrent <= 0 %}
 concurrent =  {{ ansible_processor_cores|default(2, true) }}
+{% else %}
+concurrent =  {{ gitlab_concurrent }}
+{% endif %}
 check_interval = 0
 
 [session_server]


### PR DESCRIPTION
I need to be able to set the number of conccurrent jobs that can run on a runner manually for a very compute intensive set of jobs. This PR allows the ability to set a `gitlab_concurrent` variable for this. The default behaviour of using the `ansible_processor_cores` for this is still in effect.